### PR TITLE
Support for latest ActiveAdmin version `per_page`

### DIFF
--- a/lib/active_admin/xls/resource_controller_extension.rb
+++ b/lib/active_admin/xls/resource_controller_extension.rb
@@ -23,7 +23,7 @@ module ActiveAdmin
       # patching per_page to use the CSV record max for pagination when the format is xls
       def per_page_with_xls
         if request.format ==  Mime::Type.lookup_by_extension(:xls)
-          return max_per_page
+          return respond_to?(:max_per_page) ? max_per_page : active_admin_config.max_per_page
         end
 
         per_page_without_xls


### PR DESCRIPTION
The `max_per_page` method has been moved from the controller (hardcoded) to the resource (configurable). See related commit https://github.com/activeadmin/activeadmin/commit/77584fab44544ee5596c9ce1fd526f5e3a5c1e74

This change allows the code to work with both old and new implementation.
